### PR TITLE
fix(core): fix  issues of pie chart, donut chart  and XY chart hidden dataset by legend

### DIFF
--- a/src/charts/pie/pie.ts
+++ b/src/charts/pie/pie.ts
@@ -225,7 +225,7 @@ export class PieChart<TData extends PieData, TOptions extends PieChartOptions> e
     dataset.label = series.name;
     dataset.type = ChartType.Pie;
     dataset.backgroundColor = chartBG;
-    dataset.borderWidth = 1;
+    dataset.borderWidth = this.getBorderWidth();
     return dataset;
   }
 
@@ -250,12 +250,19 @@ export class PieChart<TData extends PieData, TOptions extends PieChartOptions> e
     if (index < 0) {
       return;
     }
+    if (
+      !datasets[0] ||
+      this.hiddenDatasets.some((hiddenDataset: { label?: string }) => hiddenDataset.label === legend.text)
+    ) {
+      return;
+    }
     this.hiddenDatasets.push({
       label: legend.text,
       backgroundColor: (datasets[0].backgroundColor as Color[])[index],
     });
     datasets.map((dataset) => {
       (dataset.backgroundColor as Color[]).splice(index, 1, this.getCurrentTheme().inactiveTextColor);
+      dataset.borderWidth = this.getBorderWidth();
     });
   }
 
@@ -271,10 +278,11 @@ export class PieChart<TData extends PieData, TOptions extends PieChartOptions> e
     const hiddenDataset = this.hiddenDatasets.find((dataset) => dataset.label === legend.text);
     if (hiddenDataset?.backgroundColor) {
       const backgroundColor = hiddenDataset.backgroundColor;
+      this.hiddenDatasets = this.hiddenDatasets.filter((dataset) => dataset.label !== legend.text);
       datasets.map((dataset) => {
         (dataset.backgroundColor as Color[]).splice(index, 1, backgroundColor);
+        dataset.borderWidth = this.getBorderWidth();
       });
-      this.hiddenDatasets = this.hiddenDatasets.filter((dataset) => dataset.label !== legend.text);
     }
   }
 
@@ -324,5 +332,16 @@ export class PieChart<TData extends PieData, TOptions extends PieChartOptions> e
     });
 
     return this.options.tooltip?.combineItems ? tooltipItems : tooltipItems.filter((item) => item.active);
+  }
+
+  private getBorderWidth(): number {
+    if (
+      this.chartData.category.labels?.length === 1 ||
+      (this.chartData.category.labels?.length &&
+        this.chartData.category.labels?.length - this.hiddenDatasets.length === 1)
+    ) {
+      return 0;
+    }
+    return 1;
   }
 }

--- a/src/charts/xy/xy.ts
+++ b/src/charts/xy/xy.ts
@@ -637,8 +637,14 @@ export abstract class XYChart extends Chart<XYData, XYChartOptions> {
   }
 
   private setItemActiveStyle(legend: LegendItem): void {
+    if (!this.api?.data?.datasets) {
+      return;
+    }
     let dataset = this.api?.data.datasets.find((dataset) => dataset.label === legend.text);
-    if (!dataset) {
+    if (
+      !dataset ||
+      this.hiddenDatasets.some((hiddenDataset: { label?: string }) => hiddenDataset.label === legend.text)
+    ) {
       return;
     }
     dataset = dataset as ChartDataset<CJType, number[]>;


### PR DESCRIPTION
## Description

> Fix the bug that piechart cannot be displayed as a whole when only one chart series is displayed
> Fix the bug that piechart and XY chart  hidden dataset calculation error.
## Screenshots
![image](https://github.com/momentum-design/charts/assets/159236641/910aee23-7207-43b5-941c-e270c6399260)
![image](https://github.com/momentum-design/charts/assets/15923664.1/833ed315-5c36-46db-b014-61a26247d9cc)
![image](https://github.com/momentum-design/charts/assets/159236641/923a049a-ca70-41f1-9d94-f3af5a341389)



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation or example update


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation and example
