### PR TITLE
fix(tooltip): padding of the parent element causes positioning errors

### DIFF
--- a/src/charts/tooltip/tooltip.ts
+++ b/src/charts/tooltip/tooltip.ts
@@ -255,20 +255,22 @@ export class Tooltip<TChart extends Chart<ChartData, ChartOptions>> {
 
   // set the position of the tooltip dynamically
   private setPosition(context: any, tooltip: any, arrowEl: DomElement, tooltipEl: DomElement): void {
-    let left = '';
-    let top = '';
+    let left = 0;
+    let top = 0;
     if (this.options.appendToBody) {
       const position = context.chart.canvas.getBoundingClientRect();
-      left = position.left + window.scrollX + tooltip.caretX + 'px';
-      top = position.top + window.scrollY + tooltip.caretY + 'px';
-    } else {
-      left = tooltip.caretX + 'px';
-      top = tooltip.caretY + 'px';
+      left = position.left + window.scrollX;
+      top = position.top + window.scrollY;
     }
+    const styles = getComputedStyle(context.chart.canvas.parentElement);
+    const parentElementPaddingTop = styles.paddingTop;
+    const parentElementPaddingLeft = styles.paddingLeft;
+    left += tooltip.caretX + parseFloat(parentElementPaddingLeft);
+    top += tooltip.caretY + parseFloat(parentElementPaddingTop);
     // display, position, and set styles
     tooltipEl.setStyle('opacity', '1');
-    tooltipEl.setStyle('left', left);
-    tooltipEl.setStyle('top', top);
+    tooltipEl.setStyle('left', left + 'px');
+    tooltipEl.setStyle('top', top + 'px');
     tooltipEl.setStyle('z-index', this.options.zIndex);
 
     const alignKey = `${tooltip.xAlign}-${tooltip.yAlign}` as PositionDirection;


### PR DESCRIPTION
## Description

> Setting the padding of the parent node of the canvas can cause the tooltip to be misaligned.


## Screenshots
Before
![image](https://github.com/momentum-design/charts/assets/20723412/61bb9274-fb3b-4054-aa4c-eb4b496edbfe)
After
![image](https://github.com/momentum-design/charts/assets/20723412/43048396-1070-4a45-904c-f080d4a3ee60)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation or example update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and example
