### PR TITLE
feat(xy): add click event for category label

### DIFF
--- a/src/charts/xy/xy.ts
+++ b/src/charts/xy/xy.ts
@@ -544,7 +544,8 @@ export abstract class XYChart extends Chart<XYData, XYChartOptions> {
     dataset: ChartDataset<'line', number[]>,
     styleMapping: SeriesStyleOptions,
   ): MarkerStyle | undefined {
-    dataset.pointRadius = dataset.data.length > 1 ? 0 : 2;
+    // If pointRadius is 0, the boundary line point is not fully displayed when hovered.
+    dataset.pointRadius = dataset.data.length > 1 ? 0.01 : 2;
     dataset.pointHoverRadius = 5;
     return styleMapping.markerStyle ?? this.options.legend?.markerStyle;
   }

--- a/src/types/chart.event.types.ts
+++ b/src/types/chart.event.types.ts
@@ -6,7 +6,8 @@ export enum ChartEventType {
   LegendItemClick = 'legendItemClick',
   LegendItemSelect = 'legendItemSelect',
   LegendItemUnselect = 'legendItemUnselect',
-  SegmentItemClick = 'SegmentItemClick',
+  CategoryLabelClick = 'categoryLabelClick',
+  SegmentItemClick = 'segmentItemClick',
   ThemeChange = 'themeChange',
   WordClick = 'wordClick',
   Wheel = 'wheel',
@@ -26,12 +27,11 @@ export class ChartEvent<TData> extends Event {
   constructor(name: ChartEventType, public context?: EventContext<TData>, options?: EventInit) {
     super(
       name,
-      options ||
-        {
-          // bubbles: true,
-          // cancelable: true,
-          // composed: true,
-        },
+      options || {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      },
     );
   }
 


### PR DESCRIPTION
## Description

>1. Add click event for category label
>2. Fixed the issue that the point display of the boundary line is incomplete


## Screenshots
 Before
<img width="1061" alt="image" src="https://github.com/momentum-design/charts/assets/20723412/a4b69832-25d5-429e-a4f2-1440fed4bf66">

After
<img width="1074" alt="image" src="https://github.com/momentum-design/charts/assets/20723412/ed8d52b4-7de6-4aa2-aa2c-3fffcd719ebe">


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation or example update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and example
