### PR TITLE
fix(donut): adjust font usage order of center label

### DIFF
--- a/src/charts/donut/donut.ts
+++ b/src/charts/donut/donut.ts
@@ -5,7 +5,7 @@ import {
 } from 'chart.js/auto';
 import { getFontStyleAbbreviation } from '../../core';
 import { deepClone, mergeObjects } from '../../helpers';
-import { ChartType, Position } from '../../types';
+import { ChartType, Font, Position } from '../../types';
 import { PieChart } from '../pie';
 import { CenterLabel, DonutChartOptions, DonutData } from './donut.type';
 
@@ -87,19 +87,14 @@ export class DonutChart extends PieChart<DonutData, DonutChartOptions> {
         // ignore items after second one
         return;
       }
-
-      if (!label.font) {
-        label.font = {};
-      }
-
       const cjFont = this.getCJFont(label.font || {}, {
         size: index === 0 ? 36 : 14,
       });
-      if (cjFont.size) {
+      if (!label.font && cjFont.size) {
         cjFont.size = cjFont.size * scaleNum;
       }
       // required as the following offset will use the size.
-      label.font.size = cjFont.size;
+      label.font = cjFont as Font;
 
       let topOffset = 0;
       if (centerLabels.length > 1 && centerLabels[0]?.font?.size) {


### PR DESCRIPTION
## Description

> Adjust font usage order of center label, If the font is set separately, it will not scale dynamically.





## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation or example update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation and example
