### PR TITLE
fix(tooltip): inaccurate position when parent element has padding

### DIFF
--- a/src/charts/legend/legend.ts
+++ b/src/charts/legend/legend.ts
@@ -257,7 +257,7 @@ export class Legend<TChart extends Chart<ChartData, ChartOptions>> {
         tooltipLeft = left + width / 2;
         tooltipTop = top + height;
       }
-      setPosition(alignKey, tooltipEl, tooltipLeft, tooltipTop, this.chart.getCurrentTheme());
+      setPosition(alignKey, tooltipEl, tooltipLeft, tooltipTop, this.chart.getCurrentTheme(), chart);
       this.tooltipElement = tooltipEl;
     }
   }

--- a/src/charts/tooltip/tooltip.helper.ts
+++ b/src/charts/tooltip/tooltip.helper.ts
@@ -161,6 +161,7 @@ export function setPosition(
   left: number,
   top: number,
   theme: Theme,
+  chart?: any,
 ): void {
   const arrowEl = findDomElement(`.${TOOLTIP_CLASS}-arrow`, tooltipEl.nativeElement);
   const currentPosition = TooltipPositions[alignKey];
@@ -183,6 +184,13 @@ export function setPosition(
     tooltipEl.setStyle('transform', currentPosition.transform);
   } else {
     tooltipEl.addClass('no-transform');
+  }
+  if (chart?.canvas?.parentElement) {
+    const styles = getComputedStyle(chart.canvas.parentElement);
+    const parentElementPaddingTop = styles.paddingTop;
+    const parentElementPaddingLeft = styles.paddingLeft;
+    left = left + parseFloat(parentElementPaddingLeft);
+    top = top + parseFloat(parentElementPaddingTop);
   }
   tooltipEl.setStyle('left', left + 'px');
   tooltipEl.setStyle('top', top + 'px');

--- a/src/charts/tooltip/tooltip.ts
+++ b/src/charts/tooltip/tooltip.ts
@@ -210,16 +210,13 @@ export class Tooltip<TChart extends Chart<ChartData, ChartOptions>> {
       left = position.left + window.scrollX;
       top = position.top + window.scrollY;
     }
-    const styles = getComputedStyle(context.chart.canvas.parentElement);
-    const parentElementPaddingTop = styles.paddingTop;
-    const parentElementPaddingLeft = styles.paddingLeft;
-    left += tooltip.caretX + parseFloat(parentElementPaddingLeft);
-    top += tooltip.caretY + parseFloat(parentElementPaddingTop);
+    left += tooltip.caretX;
+    top += tooltip.caretY;
     // display, position, and set styles
     tooltipEl.setStyle('z-index', this.options.zIndex);
     tooltipEl.setStyle('line-height', '1.5');
     const alignKey = `${tooltip.xAlign}-${tooltip.yAlign}` as PositionDirection;
-    setPosition(alignKey, tooltipEl, left, top, this.chart.getCurrentTheme());
+    setPosition(alignKey, tooltipEl, left, top, this.chart.getCurrentTheme(), context.chart);
   }
 
   private generateHtmlForIcon(tooltipItem: TooltipItem): DomElement {

--- a/src/charts/xy/xy.category-tooltip.ts
+++ b/src/charts/xy/xy.category-tooltip.ts
@@ -17,11 +17,6 @@ export class CategoryLabelTooltip<TChart extends Chart<ChartData, ChartOptions>>
   toCJPlugin(): Plugin {
     return {
       id: 'categoryLabelTooltip',
-      start: () => {},
-      beforeInit: () => {},
-      afterRender: (chart: CJ<ChartType.Bar | ChartType.Line>) => {
-        this.initHitBoxes(chart);
-      },
       afterEvent: (
         chart: CJ<ChartType.Bar | ChartType.Line>,
         event: {
@@ -33,17 +28,18 @@ export class CategoryLabelTooltip<TChart extends Chart<ChartData, ChartOptions>>
         },
       ) => {
         const { type, x, y } = event.event;
-        if (type == 'mousemove' && typeof x === 'number' && typeof y === 'number') {
+        if (type === 'mousemove' && typeof x === 'number' && typeof y === 'number') {
           const categoryScale = Object.values(chart.scales).find((scale) => scale.id === ScaleKeys.CategoryAxis);
           if (!categoryScale) {
             return;
           }
+          this.initHitBoxes(chart);
           const hitBox = this.getHitBoxByXY(x, y);
           if (!hitBox) {
             return;
           }
           this.hoverLabel(categoryScale.position as Position, hitBox);
-        } else if (type == 'mouseout') {
+        } else if (type === 'mouseout') {
           this.leaveLabel();
         }
       },
@@ -106,6 +102,7 @@ export class CategoryLabelTooltip<TChart extends Chart<ChartData, ChartOptions>>
         hitBox.left,
         hitBox.top,
         this.chart.getCurrentTheme(),
+        chart,
       );
       this.tooltipElement = tooltipEl;
     }
@@ -116,7 +113,7 @@ export class CategoryLabelTooltip<TChart extends Chart<ChartData, ChartOptions>>
   }
 
   private initHitBoxes(chart: CJ<ChartType.Bar | ChartType.Line>): void {
-    if (chart.scales && this.hitBoxes.length === 0) {
+    if (chart.scales) {
       const categoryScale = Object.values(chart.scales).find((scale) => scale.id === ScaleKeys.CategoryAxis);
       if (categoryScale) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Description

> 1. Fixed inaccurate positioning when the parent element has padding.
> 2. Positioning errors caused by different bar chart label lengths.


## Screenshots

- [x] This PR does not have any UI modifications <!-- remove this line and attach the screenshots if you have any UI changes --> 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation or example update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation and example
